### PR TITLE
feat:add snap build

### DIFF
--- a/etcd.conf.yml
+++ b/etcd.conf.yml
@@ -1,0 +1,157 @@
+# This is the configuration file for the etcd server.
+
+# Human-readable name for this member.
+name: 'default'
+
+# Path to the data directory.
+data-dir:
+
+# Path to the dedicated wal directory.
+wal-dir:
+
+# Number of committed transactions to trigger a snapshot to disk.
+snapshot-count: 10000
+
+# Time (in milliseconds) of a heartbeat interval.
+heartbeat-interval: 100
+
+# Time (in milliseconds) for an election to timeout.
+election-timeout: 1000
+
+# Raise alarms when backend size exceeds the given quota. 0 means use the
+# default quota.
+quota-backend-bytes: 0
+
+# List of comma separated URLs to listen on for peer traffic.
+listen-peer-urls: http://localhost:2380
+
+# List of comma separated URLs to listen on for client traffic.
+listen-client-urls: http://localhost:2379
+
+# Maximum number of snapshot files to retain (0 is unlimited).
+max-snapshots: 5
+
+# Maximum number of wal files to retain (0 is unlimited).
+max-wals: 5
+
+# Comma-separated white list of origins for CORS (cross-origin resource sharing).
+cors:
+
+# List of this member's peer URLs to advertise to the rest of the cluster.
+# The URLs needed to be a comma-separated list.
+initial-advertise-peer-urls: http://localhost:2380
+
+# List of this member's client URLs to advertise to the public.
+# The URLs needed to be a comma-separated list.
+advertise-client-urls: http://localhost:2379
+
+# Discovery URL used to bootstrap the cluster.
+discovery:
+
+# Valid values include 'exit', 'proxy'
+discovery-fallback: 'proxy'
+
+# HTTP proxy to use for traffic to discovery service.
+discovery-proxy:
+
+# DNS domain used to bootstrap initial cluster.
+discovery-srv:
+
+# Comma separated string of initial cluster configuration for bootstrapping.
+# Example: initial-cluster: "infra0=http://10.0.1.10:2380,infra1=http://10.0.1.11:2380,infra2=http://10.0.1.12:2380"
+initial-cluster:
+
+# Initial cluster token for the etcd cluster during bootstrap.
+initial-cluster-token: 'etcd-cluster'
+
+# Initial cluster state ('new' or 'existing').
+initial-cluster-state: 'new'
+
+# Reject reconfiguration requests that would cause quorum loss.
+strict-reconfig-check: false
+
+# Enable runtime profiling data via HTTP server
+enable-pprof: true
+
+# Valid values include 'on', 'readonly', 'off'
+proxy: 'off'
+
+# Time (in milliseconds) an endpoint will be held in a failed state.
+proxy-failure-wait: 5000
+
+# Time (in milliseconds) of the endpoints refresh interval.
+proxy-refresh-interval: 30000
+
+# Time (in milliseconds) for a dial to timeout.
+proxy-dial-timeout: 1000
+
+# Time (in milliseconds) for a write to timeout.
+proxy-write-timeout: 5000
+
+# Time (in milliseconds) for a read to timeout.
+proxy-read-timeout: 0
+
+client-transport-security:
+  # Path to the client server TLS cert file.
+  cert-file:
+
+  # Path to the client server TLS key file.
+  key-file:
+
+  # Enable client cert authentication.
+  client-cert-auth: false
+
+  # Path to the client server TLS trusted CA cert file.
+  trusted-ca-file:
+
+  # Client TLS using generated certificates
+  auto-tls: false
+
+peer-transport-security:
+  # Path to the peer server TLS cert file.
+  cert-file:
+
+  # Path to the peer server TLS key file.
+  key-file:
+
+  # Enable peer client cert authentication.
+  client-cert-auth: false
+
+  # Path to the peer server TLS trusted CA cert file.
+  trusted-ca-file:
+
+  # Peer TLS using generated certificates.
+  auto-tls: false
+
+  # Allowed CN for inter peer authentication.
+  allowed-cn:
+
+  # Allowed TLS hostname for inter peer authentication.
+  allowed-hostname:
+
+# The validity period of the self-signed certificate, the unit is year.
+self-signed-cert-validity: 1
+
+# Enable debug-level logging for etcd.
+log-level: debug
+
+logger: zap
+
+# Specify 'stdout' or 'stderr' to skip journald logging even when running under systemd.
+log-outputs: [stderr]
+
+# Force to create a new one member cluster.
+force-new-cluster: false
+
+auto-compaction-mode: periodic
+auto-compaction-retention: "1"
+
+# Limit etcd to a specific set of tls cipher suites
+cipher-suites: [
+  TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+  TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+]
+
+# Limit etcd to specific TLS protocol versions 
+tls-min-version: 'TLS1.2'
+tls-max-version: 'TLS1.3'

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,38 @@
+name: charmed-etcd-snap # you probably want to 'snapcraft register <name>'
+base: core24 # the base snap is the execution environment for this snap
+version: '0.1' # just for humans, typically '1.2+git' or '1.3.2'
+summary: etcd is a distributed reliable key-value store for distributed systems. # 79 char long summary
+description: |
+  etcd is a distributed reliable key-value store for the most critical data of a distributed system.
+  etcd is written in Go and uses the Raft consensus algorithm to manage a highly-available replicated log.
+
+grade: devel # must be 'stable' to release into candidate/stable channels
+confinement: strict # use 'strict' once you have the right plugs and slots
+
+apps:
+  etcd:
+    daemon: simple
+    command: bin/etcd
+    plugs:
+      - network-bind
+  etcdctl:
+    command: bin/etcdctl
+    plugs:
+      - network-bind
+      - home
+  etcdutl:
+    command: bin/etcdutl
+    plugs:
+      - network-bind
+      - home
+
+parts:
+  etcd:
+    plugin: make
+    build-snaps: [go/latest/stable]
+    source: https://git.launchpad.net/etcd
+    source-type: git
+    source-branch: main
+    override-build: |
+      make build
+      cp -r bin $CRAFT_PART_INSTALL/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
-name: charmed-etcd-snap # you probably want to 'snapcraft register <name>'
+name: charmed-etcd # you probably want to 'snapcraft register <name>'
 base: core24 # the base snap is the execution environment for this snap
-version: '0.1' # just for humans, typically '1.2+git' or '1.3.2'
+version: '3.5.16' # just for humans, typically '1.2+git' or '1.3.2'
 summary: etcd is a distributed reliable key-value store for distributed systems. # 79 char long summary
 description: |
   etcd is a distributed reliable key-value store for the most critical data of a distributed system.
@@ -32,7 +32,7 @@ parts:
     build-snaps: [go/latest/stable]
     source: https://git.launchpad.net/etcd
     source-type: git
-    source-branch: main
+    source-branch: lp-v3.5.16
     override-build: |
       make build
       cp -r bin $CRAFT_PART_INSTALL/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -9,12 +9,24 @@ description: |
 grade: devel # must be 'stable' to release into candidate/stable channels
 confinement: strict # use 'strict' once you have the right plugs and slots
 
+environment:
+  SNAP_CURRENT: /snap/charmed-etcd/current
+  SNAP_DATA_CURRENT: /var/snap/charmed-etcd/current
+
 apps:
-  etcd:
+  daemon:
     daemon: simple
     command: bin/etcd
     plugs:
       - network-bind
+    environment:
+      ETCD_CONFIG_FILE: $SNAP_CURRENT/etcd.conf.yml
+
+  etcd:
+    command: bin/etcd
+    plugs:
+      - network-bind
+      - home
   etcdctl:
     command: bin/etcdctl
     plugs:
@@ -36,3 +48,9 @@ parts:
     override-build: |
       make build
       cp -r bin $CRAFT_PART_INSTALL/
+  
+  etcd-conf-file:
+    plugin: dump
+    source: .
+    stage:
+      - etcd.conf.yml


### PR DESCRIPTION
This pull request includes the addition of a new `snapcraft.yaml` file to configure the packaging of the `charmed-etcd-snap` application. The most important changes involve defining the snap package metadata, specifying the applications included in the snap, and detailing the parts and build instructions.

Snap package configuration:

* Added `name`, `base`, `version`, `summary`, and `description` fields to define the snap package metadata.
* Set `grade` to `devel` and `confinement` to `strict` for the snap package.

Application definitions:

* Defined three applications (`etcd`, `etcdctl`, and `etcdutl`) with their respective commands and required plugs.

Build instructions:

* Specified the `etcd` part with `make` plugin, build dependencies, source repository, and custom build commands.