### PR TITLE
[DPE-5768] - Add CI release workflow for Snap Store

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,30 @@
+# Copyright 2024 Canonical Ltd.
+# See licenses/LICENSE-snap file for licensing details.
+name: Release to Snap Store
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  push:
+    branches:
+      - 3.5/edge
+
+jobs:
+  build:
+    name: Build snap
+    uses: canonical/data-platform-workflows/.github/workflows/build_snap.yaml@v23.0.4
+
+  release:
+    name: Release snap
+    needs:
+      - build
+    uses: canonical/data-platform-workflows/.github/workflows/release_snap.yaml@v23.0.4
+    with:
+      channel: 3.5/edge
+      artifact-prefix: ${{ needs.build.outputs.artifact-prefix }}
+    secrets:
+      snap-store-token: ${{ secrets.SNAP_STORE_TOKEN }}
+    permissions:
+      contents: write  # Needed to create GitHub release


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow for releasing to the Snap Store. The most important changes include defining the workflow name and configuration, specifying the trigger for the workflow, and setting up the build and release jobs.