### PR TITLE
[DPE-6043] - Add wrappers and rename daemon

### DIFF
--- a/config/etcd.conf.yml
+++ b/config/etcd.conf.yml
@@ -4,7 +4,7 @@
 name: 'default'
 
 # Path to the data directory.
-data-dir:
+data-dir: "/var/snap/charmed-etcd/common/var/lib/etcd"
 
 # Path to the dedicated wal directory.
 wal-dir:

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -2,15 +2,15 @@
 
 # This hook is called when the snap is installed
 # copy the configuration file to the snap's data directory
-cp $SNAP/config/etcd.conf.yml $SNAP_DATA/etcd.conf.yml
+cp "${SNAP}"/config/etcd.conf.yml "${SNAP_DATA}"/etcd.conf.yml
 chown -R 584788:584788 "${SNAP_DATA}"/*
 
 # create the data directory
-export DATA="${SNAP_COMMON}"/var/lib/etcd
+DATA="${SNAP_COMMON}"/var/lib/etcd
 mkdir -p "${DATA}"
 
 # If we just created the directory, we set up permissions
-if [ stat -c '%u' "$DATA" == 0 ]; then
+if [ stat -c '%u' "${DATA}" == 0 ]; then
     chmod -R 770 "${SNAP_COMMON}"
     chmod 750 "${DATA}"
 fi

--- a/snap/hooks/install
+++ b/snap/hooks/install
@@ -3,3 +3,16 @@
 # This hook is called when the snap is installed
 # copy the configuration file to the snap's data directory
 cp $SNAP/config/etcd.conf.yml $SNAP_DATA/etcd.conf.yml
+chown -R 584788:584788 "${SNAP_DATA}"/*
+
+# create the data directory
+export DATA="${SNAP_COMMON}"/var/lib/etcd
+mkdir -p "${DATA}"
+
+# If we just created the directory, we set up permissions
+if [ stat -c '%u' "$DATA" == 0 ]; then
+    chmod -R 770 "${SNAP_COMMON}"
+    chmod 750 "${DATA}"
+fi
+
+chown -R 584788:584788 "${SNAP_COMMON}"/*

--- a/snap/local/drop_priv.sh
+++ b/snap/local/drop_priv.sh
@@ -1,5 +1,5 @@
-#!/bin/bash
-# Wrapper script for charmed mongodb applications to be run with restricted privileges
+#!/usr/bin/env bash
+# Wrapper script for charmed etcd to be run with restricted privileges
 
 pushd "${SNAP}" > /dev/null
 

--- a/snap/local/drop_priv.sh
+++ b/snap/local/drop_priv.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Wrapper script for charmed mongodb applications to be run with restricted privileges
+
+pushd "${SNAP}" > /dev/null
+
+if [[ $(id -u) == "0" ]]; then
+    exec "${SNAP}"/usr/bin/setpriv \
+        --clear-groups \
+        --reuid snap_daemon \
+        --regid snap_daemon \
+        -- \
+        "${SNAP}/bin/$@"
+else
+    exec "${SNAP}/bin/$@"
+fi
+
+popd > /dev/null

--- a/snap/local/start-etcd.sh
+++ b/snap/local/start-etcd.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# For security measures, daemons should not be run as sudo. Execute mongod as the non-sudo user: snap-daemon.
+exec $SNAP/usr/bin/setpriv --clear-groups --reuid snap_daemon --regid snap_daemon -- $SNAP/bin/etcd

--- a/snap/local/start-etcd.sh
+++ b/snap/local/start-etcd.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # For security measures, daemons should not be run as sudo. Execute mongod as the non-sudo user: snap-daemon.
-exec $SNAP/usr/bin/setpriv --clear-groups --reuid snap_daemon --regid snap_daemon -- $SNAP/bin/etcd
+exec "${SNAP}"/usr/bin/setpriv --clear-groups --reuid snap_daemon --regid snap_daemon -- "${SNAP}"/bin/etcd

--- a/snap/local/start-etcd.sh
+++ b/snap/local/start-etcd.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 
-# For security measures, daemons should not be run as sudo. Execute mongod as the non-sudo user: snap-daemon.
+# For security measures, daemons should not be run as sudo. Execute etcd as the non-sudo user: snap-daemon.
 exec "${SNAP}"/usr/bin/setpriv --clear-groups --reuid snap_daemon --regid snap_daemon -- "${SNAP}"/bin/etcd

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -9,25 +9,28 @@ description: |
 grade: devel # must be 'stable' to release into candidate/stable channels
 confinement: strict # use 'strict' once you have the right plugs and slots
 
+system-usernames:
+  snap_daemon: shared
+
 apps:
-  daemon:
+  etcd:
+    command: start-etcd.sh
     daemon: simple
-    command: bin/etcd
+    install-mode: disable
+    restart-condition: always
+    restart-delay: 20s
     plugs:
       - network-bind
     environment:
       ETCD_CONFIG_FILE: $SNAP_DATA/etcd.conf.yml
 
-  etcd:
-    command: bin/etcd
-    plugs:
-      - network-bind
   etcdctl:
-    command: bin/etcdctl
+    command: drop_priv.sh etcdctl
     plugs:
       - network-bind
+
   etcdutl:
-    command: bin/etcdutl
+    command: drop_priv.sh etcdutl
     plugs:
       - network-bind
 
@@ -35,6 +38,8 @@ parts:
   etcd:
     plugin: make
     build-snaps: [go/latest/stable]
+    stage-packages:
+      - util-linux
     source: https://git.launchpad.net/etcd
     source-type: git
     source-tag: lp-v3.5.16
@@ -47,3 +52,6 @@ parts:
     source: .
     stage:
       - config/etcd.conf.yml
+  wrapper:
+    plugin: dump
+    source: snap/local


### PR DESCRIPTION
This pull request includes several changes to improve the configuration and security of the `etcd` snap package. The most important changes involve updating configuration paths, adding scripts for privilege dropping, and modifying the `snapcraft.yaml` file to enhance security and functionality.

Configuration updates:

* [`config/etcd.conf.yml`](diffhunk://#diff-11b9dce02506e4a04e90ec8fd6ae5a1303c63b6d2f598c27a38c614233945022L7-R7): Updated the `data-dir` path to use the snap's common directory.

Security enhancements:

* [`snap/hooks/install`](diffhunk://#diff-e58b9a041906b37e03356984486699655b2d559fa8dc4d95b340a3b5be7a9a42R6-R18): Added commands to set up permissions and ownership for the snap's data directory.
* [`snap/local/drop_priv.sh`](diffhunk://#diff-73c43d081f46ddf34bf5af53db6b4768c0218d4fad21def464618f5b757a7821R1-R17): Added a new script to run applications with restricted privileges using `setpriv`.
* [`snap/local/start-etcd.sh`](diffhunk://#diff-6d0a469ae28efb2b2496d4c03e9e615ceb759f1895d764e17c0aced349ddfcb2R1-R4): Added a new script to run `etcd` as a non-sudo user for security reasons.

Functionality improvements:

* [`snap/snapcraft.yaml`](diffhunk://#diff-56759910381a014fecfd7556dd72ddd68c747d922a5b7df2044b9ce7c552f5f5R12-R42): Updated the `apps` section to use the new `start-etcd.sh` script for the `etcd` command, added `system-usernames`, and modified the `etcdctl` and `etcdutl` commands to use the `drop_priv.sh` script. [[1]](diffhunk://#diff-56759910381a014fecfd7556dd72ddd68c747d922a5b7df2044b9ce7c552f5f5R12-R42) [[2]](diffhunk://#diff-56759910381a014fecfd7556dd72ddd68c747d922a5b7df2044b9ce7c552f5f5R55-R57)