### PR TITLE
[DPE-5768] - add release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,30 @@
+# Copyright 2024 Canonical Ltd.
+# See licenses/LICENSE-snap file for licensing details.
+name: Release to Snap Store
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  push:
+    branches:
+      - 3.5/edge
+
+jobs:
+  build:
+    name: Build snap
+    uses: canonical/data-platform-workflows/.github/workflows/build_snap.yaml@v23.0.4
+
+  release:
+    name: Release snap
+    needs:
+      - build
+    uses: canonical/data-platform-workflows/.github/workflows/release_snap.yaml@v23.0.4
+    with:
+      channel: 3.5/edge
+      artifact-prefix: ${{ needs.build.outputs.artifact-prefix }}
+    secrets:
+      snap-store-token: ${{ secrets.SNAP_STORE_TOKEN }}
+    permissions:
+      contents: write # Needed to create GitHub release


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the release process to the Snap Store. The most important changes include adding licensing details, defining the workflow name and concurrency settings, specifying the trigger conditions, and setting up the build and release jobs.

New GitHub Actions workflow:

* [`.github/workflows/release.yaml`](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaR1-R30): 
  * Added licensing details, defined the workflow name as "Release to Snap Store", and set concurrency settings to cancel in-progress runs for the same workflow and branch.
  * Specified the workflow trigger to run on pushes to the `3.5/edge` branch.
  * Added a build job using the `canonical/data-platform-workflows/.github/workflows/build_snap.yaml@v23.0.4` workflow.
  * Added a release job that depends on the build job, using the `canonical/data-platform-workflows/.github/workflows/release_snap.yaml@v23.0.4` workflow, and configured it with the necessary channel, artifact prefix, and secrets.