### PR TITLE
[DPE-6341] - Upgrade etcd to v3.5.18

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ on:
 jobs:
   build:
     name: Build snap
-    uses: canonical/data-platform-workflows/.github/workflows/build_snap.yaml@v23.0.4
+    uses: canonical/data-platform-workflows/.github/workflows/build_snap.yaml@v29.0.5
 
   test:
     name: Test snap

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,13 +14,13 @@ on:
 jobs:
   build:
     name: Build snap
-    uses: canonical/data-platform-workflows/.github/workflows/build_snap.yaml@v23.0.4
+    uses: canonical/data-platform-workflows/.github/workflows/build_snap.yaml@v29.0.5
 
   release:
     name: Release snap
     needs:
       - build
-    uses: canonical/data-platform-workflows/.github/workflows/release_snap.yaml@v23.0.4
+    uses: canonical/data-platform-workflows/.github/workflows/release_snap.yaml@v29.0.5
     with:
       channel: 3.5/edge
       artifact-prefix: ${{ needs.build.outputs.artifact-prefix }}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: charmed-etcd # you probably want to 'snapcraft register <name>'
 base: core24 # the base snap is the execution environment for this snap
-version: '3.5.16' # just for humans, typically '1.2+git' or '1.3.2'
+version: "3.5.18" # just for humans, typically '1.2+git' or '1.3.2'
 summary: etcd is a distributed reliable key-value store for distributed systems. # 79 char long summary
 description: |
   etcd is a distributed reliable key-value store for the most critical data of a distributed system.
@@ -42,11 +42,11 @@ parts:
       - util-linux
     source: https://git.launchpad.net/etcd
     source-type: git
-    source-tag: lp-v3.5.16
+    source-tag: lp-v3.5.18
     override-build: |
       make build
       cp -r bin $CRAFT_PART_INSTALL/
-  
+
   etcd-conf-file:
     plugin: dump
     source: .

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -8,6 +8,8 @@ description: |
 
 grade: devel # must be 'stable' to release into candidate/stable channels
 confinement: strict # use 'strict' once you have the right plugs and slots
+platforms:
+  amd64:
 
 system-usernames:
   snap_daemon: shared


### PR DESCRIPTION
Upgrade etcd to 3.5.18 from Launchpad.

Version updates:

* [`snap/snapcraft.yaml`](diffhunk://#diff-56759910381a014fecfd7556dd72ddd68c747d922a5b7df2044b9ce7c552f5f5L3-R3): Updated the version from `3.5.16` to `3.5.18`.

Source tag updates:

* [`snap/snapcraft.yaml`](diffhunk://#diff-56759910381a014fecfd7556dd72ddd68c747d922a5b7df2044b9ce7c552f5f5L45-R45): Changed the `source-tag` from `lp-v3.5.16` to `lp-v3.5.18` in the `parts` section.