### PR TITLE
[DPE-6844] - Add arm64

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -10,6 +10,7 @@ grade: devel # must be 'stable' to release into candidate/stable channels
 confinement: strict # use 'strict' once you have the right plugs and slots
 platforms:
   amd64:
+  arm64:
 
 system-usernames:
   snap_daemon: shared


### PR DESCRIPTION
The change adds support for the `arm64` platform.

* [`snap/snapcraft.yaml`](diffhunk://#diff-56759910381a014fecfd7556dd72ddd68c747d922a5b7df2044b9ce7c552f5f5R13): Added `arm64` to the list of supported platforms.