### PR TITLE
[DPE-7331] update to 3.6

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,7 +9,7 @@ concurrency:
 on:
   push:
     branches:
-      - 3.5/edge
+      - 3.6/edge
 
 jobs:
   build:
@@ -22,7 +22,7 @@ jobs:
       - build
     uses: canonical/data-platform-workflows/.github/workflows/release_snap.yaml@v29.0.5
     with:
-      channel: 3.5/edge
+      channel: 3.6/edge
       artifact-prefix: ${{ needs.build.outputs.artifact-prefix }}
     secrets:
       snap-store-token: ${{ secrets.SNAP_STORE_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Charmed etcd Snap
-<!-- [![Release to Snap Store](https://github.com/canonical/charmed-pgbouncer-snap/actions/workflows/release.yaml/badge.svg)](https://github.com/canonical/charmed-pgbouncer-snap/actions/workflows/release.yaml) -->
+<!-- [![Release to Snap Store](https://github.com/canonical/charmed-etcd-snap/actions/workflows/release.yaml/badge.svg)](https://github.com/canonical/charmed-etcd-snap/actions/workflows/release.yaml) -->
 
 This repository contains the packaging metadata for creating a snap of etcd built from Launchpad.  For more information on snaps, visit [snapcraft.io](https://snapcraft.io/). 
 
@@ -7,7 +7,7 @@ This repository contains the packaging metadata for creating a snap of etcd buil
 The snap can be installed directly from the Stap Store.  Follow the link below for more information.
 <br>
 
-[![Get it from the Snap Store](https://snapcraft.io/static/images/badges/en/snap-store-black.svg)](https://snapcraft.io/charmed-pgbouncer) -->
+[![Get it from the Snap Store](https://snapcraft.io/static/images/badges/en/snap-store-black.svg)](https://snapcraft.io/charmed-etcd) -->
 
 ## Building the Snap
 ### Clone Repository

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: charmed-etcd # you probably want to 'snapcraft register <name>'
 base: core24 # the base snap is the execution environment for this snap
-version: "3.5.21" # just for humans, typically '1.2+git' or '1.3.2'
+version: "3.6.0" # just for humans, typically '1.2+git' or '1.3.2'
 summary: etcd is a distributed reliable key-value store for distributed systems. # 79 char long summary
 description: |
   etcd is a distributed reliable key-value store for the most critical data of a distributed system.
@@ -45,7 +45,7 @@ parts:
       - util-linux
     source: https://git.launchpad.net/etcd
     source-type: git
-    source-tag: lp-v3.5.21
+    source-tag: lp-v3.6.0
     override-build: |
       make build
       cp -r bin $CRAFT_PART_INSTALL/


### PR DESCRIPTION
This PR updates the charmed-etcd snap to the recently released version 3.6.0 of etcd and also adjusts the github workflows to this. The new default branch after merging should be `3.6/edge`.