### PR TITLE
[DPE-7541] chore: Add reasonable log config values

### DIFF
--- a/config/etcd.conf.yml
+++ b/config/etcd.conf.yml
@@ -73,24 +73,6 @@ strict-reconfig-check: false
 # Enable runtime profiling data via HTTP server
 enable-pprof: true
 
-# Valid values include 'on', 'readonly', 'off'
-proxy: 'off'
-
-# Time (in milliseconds) an endpoint will be held in a failed state.
-proxy-failure-wait: 5000
-
-# Time (in milliseconds) of the endpoints refresh interval.
-proxy-refresh-interval: 30000
-
-# Time (in milliseconds) for a dial to timeout.
-proxy-dial-timeout: 1000
-
-# Time (in milliseconds) for a write to timeout.
-proxy-write-timeout: 5000
-
-# Time (in milliseconds) for a read to timeout.
-proxy-read-timeout: 0
-
 client-transport-security:
   # Path to the client server TLS cert file.
   cert-file:

--- a/config/etcd.conf.yml
+++ b/config/etcd.conf.yml
@@ -4,7 +4,7 @@
 name: 'default'
 
 # Path to the data directory.
-data-dir: "/var/snap/charmed-etcd/common/var/lib/etcd"
+data-dir: '/var/snap/charmed-etcd/common/var/lib/etcd'
 
 # Path to the dedicated wal directory.
 wal-dir:
@@ -133,25 +133,26 @@ peer-transport-security:
 self-signed-cert-validity: 1
 
 # Enable debug-level logging for etcd.
-log-level: debug
+log-level: info
 
 logger: zap
 
-# Specify 'stdout' or 'stderr' to skip journald logging even when running under systemd.
-log-outputs: [stderr]
+log-outputs: ['/var/snap/charmed-etcd/common/var/log/etcd/etcd.log']
+
+enable-log-rotation: true
+
+log-rotation-config-json: '{"maxsize": 100, "maxage": 0, "maxbackups": 0, "localtime": false, "compress": false}'
 
 # Force to create a new one member cluster.
 force-new-cluster: false
 
 auto-compaction-mode: periodic
-auto-compaction-retention: "1"
+auto-compaction-retention: '1'
 
 # Limit etcd to a specific set of tls cipher suites
-cipher-suites: [
-  TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-  TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
-]
+cipher-suites:
+  [TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256, TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384]
 
-# Limit etcd to specific TLS protocol versions 
+# Limit etcd to specific TLS protocol versions
 tls-min-version: 'TLS1.2'
 tls-max-version: 'TLS1.3'


### PR DESCRIPTION
Fixes #14 
This pull request updates the `config/etcd.conf.yml` file to improve configuration consistency, enhance logging capabilities, and ensure better maintainability. The most significant changes include standardizing string quoting, updating logging configurations, and modifying the format of certain configuration fields.

### Configuration consistency improvements:
* Standardized string quoting throughout the file by switching from double quotes to single quotes for consistency. [[1]](diffhunk://#diff-11b9dce02506e4a04e90ec8fd6ae5a1303c63b6d2f598c27a38c614233945022L7-R7) [[2]](diffhunk://#diff-11b9dce02506e4a04e90ec8fd6ae5a1303c63b6d2f598c27a38c614233945022L136-R154)

### Logging enhancements:
* Changed the log level from `debug` to `info` to reduce verbosity in production environments.
* Updated `log-outputs` to specify a file path (`'/var/snap/charmed-etcd/common/var/log/etcd/etcd.log'`) instead of `stderr`.
* Enabled log rotation with a new configuration (`enable-log-rotation: true`) and added a JSON-based log rotation configuration (`log-rotation-config-json`).

### Configuration format adjustments:
* Reformatted the `cipher-suites` field to a single-line array for cleaner syntax.