### PR TITLE
[DPE-7869] Update to 3.6.3

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: charmed-etcd # you probably want to 'snapcraft register <name>'
 base: core24 # the base snap is the execution environment for this snap
-version: "3.6.1" # just for humans, typically '1.2+git' or '1.3.2'
+version: "3.6.2" # just for humans, typically '1.2+git' or '1.3.2'
 summary: etcd is a distributed reliable key-value store for distributed systems. # 79 char long summary
 description: |
   etcd is a distributed reliable key-value store for the most critical data of a distributed system.
@@ -45,7 +45,7 @@ parts:
       - util-linux
     source: https://git.launchpad.net/etcd
     source-type: git
-    source-tag: lp-v3.6.1
+    source-tag: lp-v3.6.2
     override-build: |
       make build
       cp -r bin $CRAFT_PART_INSTALL/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: charmed-etcd # you probably want to 'snapcraft register <name>'
 base: core24 # the base snap is the execution environment for this snap
-version: "3.6.2" # just for humans, typically '1.2+git' or '1.3.2'
+version: "3.6.3" # just for humans, typically '1.2+git' or '1.3.2'
 summary: etcd is a distributed reliable key-value store for distributed systems. # 79 char long summary
 description: |
   etcd is a distributed reliable key-value store for the most critical data of a distributed system.
@@ -45,7 +45,7 @@ parts:
       - util-linux
     source: https://git.launchpad.net/etcd
     source-type: git
-    source-tag: lp-v3.6.2
+    source-tag: lp-v3.6.3
     override-build: |
       make build
       cp -r bin $CRAFT_PART_INSTALL/


### PR DESCRIPTION
Upstream release 3.6.3 has been published: [link](https://github.com/etcd-io/etcd/releases/tag/v3.6.3)

This PR updates the snap to use this new version of etcd.