### PR TITLE
[DPE-10516] update etcd to 3.6.13

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,7 +1,7 @@
 name: charmed-etcd # you probably want to 'snapcraft register <name>'
 title: Charmed etcd
 base: core24 # the base snap is the execution environment for this snap
-version: "3.6.12" # just for humans, typically '1.2+git' or '1.3.2'
+version: "3.6.13" # just for humans, typically '1.2+git' or '1.3.2'
 summary: etcd is a distributed reliable key-value store for distributed systems. # 79 char long summary
 description: |
   etcd is a distributed reliable key-value store for the most critical data of a distributed system.
@@ -74,7 +74,7 @@ parts:
       - bc
     source: https://git.launchpad.net/etcd
     source-type: git
-    source-tag: lp-v3.6.12
+    source-tag: lp-v3.6.13
     override-build: |
       make build
       cp -r bin $CRAFT_PART_INSTALL/


### PR DESCRIPTION
This PR updates the charmed-etcd snap with version 3.6.13 of upstream etcd. Changelog see https://github.com/etcd-io/etcd/blob/main/CHANGELOG/CHANGELOG-3.6.md#v3613-2026-07-01